### PR TITLE
chore(types): remove all `any` types

### DIFF
--- a/src/createElement.ts
+++ b/src/createElement.ts
@@ -1,4 +1,4 @@
-const createElement = (tag: string | (() => Node), props: null | { [key: string]: any }, ...children: Array<string | Node>): Node => {
+const createElement = (tag: string | (() => Node), props: null | { [key: string]: unknown }, ...children: Array<string | Node>): Node => {
   if (typeof tag !== 'string') {
     return tag()
   }


### PR DESCRIPTION
Fixes: #2

- Although this doesn't make the types more explicit, that will be an ongoing process